### PR TITLE
add github actions workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,3 +1,0 @@
-workflow "New workflow" {
-  on = "push"
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  schedule:
+  - cron: '0 10 1 * *'
+  push:
+  pull_request:
+jobs:
+  spec:
+    name: Spec
+    runs-on: ubuntu-latest
+
+    container:
+      image: crystallang/crystal:latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Crystal Version
+      run: |
+        crystal --version
+    - name: Run Accord Specs
+      run: |
+        crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: crystal
-notifications: 
-  email: false
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Accord
 
-[![Build Status](https://travis-ci.org/neovintage/accord.svg?branch=master)](https://travis-ci.org/neovintage/accord)
-
 A validation library for Crystal Objects which takes its inspiration from [Valcro](https://github.com/hgmnz/valcro), a simple validation library for Ruby. There are some differences between the Crystal version and Ruby that you'll need to pay attention to.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Accord
 
+![CI](https://github.com/neovintage/accord/workflows/CI/badge.svg)
+
 A validation library for Crystal Objects which takes its inspiration from [Valcro](https://github.com/hgmnz/valcro), a simple validation library for Ruby. There are some differences between the Crystal version and Ruby that you'll need to pay attention to.
 
 ## Installation


### PR DESCRIPTION
Adding a new github actions workflow file with periodic monthly builds. The monthly build should be able to catch new versions of crystal since its using the latest container image.